### PR TITLE
fix prevent-looting feature

### DIFF
--- a/Standalone-Packages/G12-PreventLooting/preventLooting.d
+++ b/Standalone-Packages/G12-PreventLooting/preventLooting.d
@@ -16,7 +16,7 @@ func void _eventOpenDeadNPC (var int dummyVariable) {
 		};
 
 		if (symbID != -1) {
-			MEM_PushInstParam (slf);
+			MEM_PushInstParam (oth);
 
 			MEM_CallByID (symbID);
 			retVal = MEM_PopIntResult ();


### PR DESCRIPTION
Now sending focus Npc as a parameter to C_Npc_PreventLooting in order to figure out whether it can be looted or not.