### PR TITLE
Make CtoB page-boundary safe

### DIFF
--- a/strings.d
+++ b/strings.d
@@ -189,7 +189,7 @@ func int STR_IndexOfFrom (var string str, var string tok, var int startFrom) {
  */
 func int CtoB (var string s) {
 	var int buf; buf = STR_toChar (s);
-	var int chr; chr = MEM_ReadInt (buf) & 255;
+	var int chr; chr = MEM_ReadByte (buf);
 	return chr;
 };
 


### PR DESCRIPTION
Provided you are using Ikarus >= 1.2.1 this little change should suffice to fix #64.

`MEM_ReadByte` will only read one byte with no risk of crossing page boundaries (Ikarus v1.2.1 onwards, ref Lehona/Ikarus#6) .

